### PR TITLE
add cursor:pointer to .nq-link

### DIFF
--- a/src/typography.css
+++ b/src/typography.css
@@ -87,6 +87,7 @@ body {
 .nq-style a {
     color: var(--nimiq-light-blue);
     text-decoration: none;
+    cursor: pointer;
 }
 
 .nq-link:active,


### PR DESCRIPTION
Make sure links look clickable with `cursor: pointer` even if they don't have a `href`.