### PR TITLE
Automatic dark mode

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -267,6 +267,23 @@
                     </div>
                 </div>
 
+                <div class="nq-card" id="dark">
+                    <div class="nq-card-header">
+                        <h1 class="nq-h1">
+                            <a href="#dark">Dark mode</a>
+                        </h1>
+                        <span class="nq-label nq-notice info">New</span>
+                    </div>
+                    <div class="nq-card-body">
+                        <p class="nq-text">
+                            Dark mode was designed to make things easy on the eyes, not to simulate reading by candlelight.
+                        </p>
+                        <p class="nq-text">
+                            To see it in action, please activate dark appearance in your operating system settings.
+                        </p>
+                    </div>
+                </div>
+
                 <div class="nq-card" id="typography">
                     <div class="nq-card-header">
                         <h1 class="nq-h1"><a href="#typography">Typography</a></h1>

--- a/src/auto-dark.css
+++ b/src/auto-dark.css
@@ -1,0 +1,114 @@
+@media (prefers-color-scheme: dark) {
+    html {
+        --nimiq-light-blue: var(--nimiq-light-blue-on-dark);
+        --nimiq-red:        var(--nimiq-red-on-dark);
+        --nimiq-card-bg:    var(--nimiq-blue);
+    }
+
+    body {
+        color: var(--nimiq-white);
+        background: var(--nimiq-dark-blue);
+    }
+
+    .nq-link {
+        color: var(--nimiq-white);
+    }
+
+    .nq-style p,
+    .nq-text, .nq-label {
+        color: rgba(255, 255, 255, 0.7);
+    }
+
+
+    /* Buttons */
+    .nq-button {
+        /* on components with white background reset to original colors */
+        --nimiq-light-blue: #0582CA; /* rgb(5, 130, 202) */
+        --nimiq-red:        #D94432; /* rgb(216, 65, 51) */
+    }
+
+    .nq-button:not(.light-blue):not(.green):not(.orange):not(.red):not(.gold):not([disabled]) {
+        background: var(--nimiq-white);
+        color: var(--nimiq-blue);
+    }
+
+    .nq-button:not(.light-blue):not(.green):not(.orange):not(.red):not(.gold):not([disabled])::before {
+        background-image: var(--nimiq-white);
+    }
+
+    .nq-button::before {
+        background: #EFF0F2; /* Indigo 7% */
+    }
+
+    .nq-button[disabled],
+    .nq-button[disabled]:hover,
+    .nq-button[disabled]:active {
+        background: rgba(255, 255, 255, 0.2);
+        color: rgba(255, 255, 255, 0.5);
+    }
+
+    .nq-button::after,
+    .nq-button-s::after,
+    .nq-button-pill::after {
+        border-color: rgba(255, 255, 255, 0.4);
+    }
+
+
+    .nq-button-s {
+        background: rgba(255, 255, 255, 0.2);
+        color: var(--nimiq-white);
+    }
+
+    .nq-button-s:hover,
+    .nq-button-s:focus,
+    .nq-button-s:active {
+        background: rgba(255, 255, 255, 0.25);
+        color: var(--nimiq-white);
+    }
+
+    .nq-button-s[disabled]:hover {
+        background: rgba(255, 255, 255, 0.2);
+    }
+
+
+    .nq-button-pill:not(.light-blue):not(.green):not(.orange):not(.red):not(.gold):not([disabled]) {
+        background: var(--nimiq-white);
+        color: var(--nimiq-blue);
+    }
+
+    .nq-button-pill:not(.light-blue):not(.green):not(.orange):not(.red):not(.gold):not([disabled])::before {
+        background-image: var(--nimiq-white);
+    }
+
+
+    /* Inputs */
+    .nq-input, .nq-input-s {
+        --border-color: rgba(255, 255, 255, 0.2);
+        color: var(--nimiq-white);
+    }
+
+    .nq-input:hover,
+    .nq-input:focus,
+    .nq-input-s:hover,
+    .nq-input-s:focus,
+    .nq-input.vanishing:focus,
+    .nq-input-s.vanishing:focus {
+        --border-color: rgba(255, 255, 255, 0.3);
+        color: var(--nimiq-white);
+    }
+
+    .nq-input::placeholder,
+    .nq-input-s::placeholder,
+    .nq-input:hover::placeholder,
+    .nq-input:focus::placeholder,
+    .nq-input-s:hover::placeholder,
+    .nq-input-s:focus::placeholder {
+        color: rgba(255, 255, 255, 0.3);
+    }
+
+
+    /* Cards */
+    .nq-card {
+        color: var(--nimiq-white);
+    }
+}

--- a/src/main.css
+++ b/src/main.css
@@ -11,6 +11,7 @@ Styleguide: https://nimiq.com/styleguide
 @import 'theme.css';
 @import 'dark-adaptions.css';
 @import 'icons.css';
+@import 'auto-dark.css';
 
 html {
     /* Transitions */

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,5 +1,6 @@
 html {
     /* Nimiq color palette */
+    --nimiq-dark-blue:  #12142b; /* rgb(18, 20, 43) */
     --nimiq-blue:       #1F2348; /* rgb(31, 35, 72) */
     --nimiq-light-blue: #0582CA; /* rgb(5, 130, 202) */
     --nimiq-gold:       #E9B213; /* rgb(233, 178, 19) */


### PR DESCRIPTION
Adds automatic dark mode support for body, links, paragraphs, labels, buttons, inputs and cards.


This may not be perfect (yet), but I wanted to see if there was any interest in pursuing this first. If you want you can visit the [demo page](https://felix-schindler.github.io/nimiq-style/demo.html).